### PR TITLE
require document, not Document

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var request = require('request'),
-	Doc = require('./lib/Document');
+	Doc = require('./lib/document');
 
 function Spider(opts) {
 	opts = this.opts = opts || {};


### PR DESCRIPTION
Requiring upper case fails on latest stable node (4.2.1) in travis.
