### PR TITLE
Do not call done unless everything is drained, not just 0 active

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,11 @@ Spider.prototype = {
 		var args = this.pending.shift();
 		if (args) {
 			this.load.apply(this, args);
-		} else if (this.opts.done && this.active.length === 0) {
+		} else if (
+			this.opts.done &&
+			this.active.length === 0 &&
+			this.pending.length === 0
+		) {
 			this.opts.done.call(this);
 		}
 	},


### PR DESCRIPTION
It seemed to me like the spider was crawling done whenever there was not an active connection.

I changed this to only call done when the queue is completely drained.

This seems to be working more like expected in my instance.
