### PR TITLE
Fix doc.resolve for pages with <base> path

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -16,7 +16,7 @@ Document.prototype = {
 	
 	resolve: function(uri) {
 		var base = this.$('base').attr('href');
-		if (base) uri = base + uri;
+		if (base && !href.match(/^http/i)) uri = base + uri;
 		
 		return url.resolve(this.url, uri);
 	}

--- a/lib/document.js
+++ b/lib/document.js
@@ -15,6 +15,9 @@ Document.prototype = {
 	},
 	
 	resolve: function(uri) {
+		var base = this.$('base').attr('href');
+		if (base) uri = base + uri;
+		
 		return url.resolve(this.url, uri);
 	}
 };

--- a/lib/document.js
+++ b/lib/document.js
@@ -16,7 +16,7 @@ Document.prototype = {
 	
 	resolve: function(uri) {
 		var base = this.$('base').attr('href');
-		if (base && !href.match(/^http/i)) uri = base + uri;
+		if (base && !uri.match(/^http/i)) uri = base + uri;
 		
 		return url.resolve(this.url, uri);
 	}

--- a/lib/document.js
+++ b/lib/document.js
@@ -16,7 +16,7 @@ Document.prototype = {
 	
 	resolve: function(uri) {
 		var base = this.$('base').attr('href');
-		if (base && !uri.match(/^http/i)) uri = base + uri;
+		if (base && !uri.match(/^(http|\/)/i)) uri = base + uri;
 		
 		return url.resolve(this.url, uri);
 	}


### PR DESCRIPTION
when `this.url` is `/some/dir`
and HTML is: `<base href="/"><a href="hello">hello</a>`
  * before: `/some/dir/hello`
  * after: `/hello`

## N.B.

I just edited this inline on Github, I didn't clone/branch and test it locally.