### PR TITLE
Don't mutate opts

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,8 +55,7 @@ Spider.prototype = {
 			this.opts.headers.Referer = referrer;
 		}
 
-		this.opts.url = url;
-		this._request(this.opts, function(err, res, _) {
+		this._request(Object.assign({}, this.opts, {url: url}), function(err, res, _) {
 			if (err) {
 				this.error(err, url);
 				return this.finished(url);


### PR DESCRIPTION
I believe this was causing an issue where the spider would call the `done` before the queue was actually complete. I could not easily reproduce on my laptop but it was regularly happening on production (slower machines). Creating this PR more for discussion than anything since I haven't explicitly proven it yet.